### PR TITLE
[BUG FIX] iFramed children elements / persistent rows in editor

### DIFF
--- a/files/js/editor_element.js
+++ b/files/js/editor_element.js
@@ -7,6 +7,9 @@
         initialize: function() {
             this.activeIndex = this.settings.get('active_index');
 
+            // if we have any iframes, we get an overlay
+            this.$el.children('.platform-element-overlay').hide();
+
             this.fixStyles();
             this.setupAccordion();
             this.setOpen();
@@ -77,12 +80,8 @@
             var view = this;
             if (this.activeIndex != '-1') {
                 this.getAccordion()
-                    .children()
-                    .filter(function() {
-                        return $(this).data('data-item') == view.activeIndex;
-                    })
-                    .children()
-                    .filter('.accordion__title')
+                    .children('[data-item="' + view.activeIndex +  '"]')
+                    .children('.accordion__title')
                     .trigger('click');
             }
         },

--- a/files/js/element.js
+++ b/files/js/element.js
@@ -7,6 +7,9 @@
         initialize: function() {
             this.activeIndex = this.settings.get('active_index');
 
+            // if we have any iframes, we get an overlay
+            this.$el.children('.platform-element-overlay').hide();
+
             this.fixStyles();
             this.setupAccordion();
         },

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest": "1",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "locale": {
     "default": "en-us",
     "supported": [
@@ -11,7 +11,7 @@
     {
       "path": "files",
       "name": "Accordion",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "settings": {
         "config": {},
         "properties": [


### PR DESCRIPTION
# 1.3.2 Patches

### Changes
* Rows are now persistent across edit reloads (last row edited/opened will remain open when page reloads)
* Can now add iFrame children elements into accordion content areas