### PR TITLE
1.3.3 Changes

### DIFF
--- a/files/js/element.js
+++ b/files/js/element.js
@@ -39,6 +39,23 @@
             this.fixBoxStyleBorders();
         },
 
+         /**
+         * Listens to size modifications in the content areas
+         * and resizes them as needed
+         */
+        listenToContentChanges: function() {
+            this.currentContent = this.getAccordion()
+                .children('[data-item="' + this.settings.get('active_index') +  '"]')
+                .children('.accordion__content');
+            if (this.currentContent[0]) {
+                this.contentInterval = setInterval(function() {
+                    if (this.currentContent[0].scrollHeight + 20 != parseInt(this.currentContent.css('max-height'))) {
+                        this.currentContent.css('max-height', this.currentContent[0].scrollHeight + 20 + 'px');
+                    }
+                }.bind(this), 50);
+            }
+        },
+
         /**
          * Simplistic jQuery usage to animate and control which
          * accordion item is currently open
@@ -47,6 +64,8 @@
             var view = this;
 
             this.getTitles().on('touchstart click', function(e) {
+                clearInterval(view.contentInterval);
+
                 // remove "hover" state on touch events
                 if (e.type == "touchstart") {
                     view.getAccordion().removeClass('no-touch');
@@ -82,9 +101,7 @@
                         'max-height': $next[0].scrollHeight + 20 + 'px' // 20 to compensate for padding
                     });
 
-                    $next.parents('.accordion__content').each(function(index, value) {
-                        view.resizeContentContainer(value, null, $next[0].scrollHeight + 20);
-                    }.bind(this));
+                    view.listenToContentChanges();
                 }
                 
             });
@@ -112,16 +129,6 @@
                     });
                 });
             }
-        },
-
-        resizeContentContainer: function(contentContainer, e, delta) {
-            if (e) {
-                e.stopPropagation();
-            }
-            var max = contentContainer.scrollHeight + 20 + delta;
-            $(contentContainer).css({
-                'max-height': max + 'px'
-            });
         },
 
         // these functions exist so that if there's nested accordions, we don't accidentally select child accordions.

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest": "1",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "locale": {
     "default": "en-us",
     "supported": [
@@ -11,7 +11,7 @@
     {
       "path": "files",
       "name": "Accordion",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "settings": {
         "config": {},
         "properties": [


### PR DESCRIPTION
Changes: 

* Updates the listenToContentChanges logic to better support accordion contents with variable sizes. Previously we were doing this with mutationObservers, but that only listened to subtree DOM modification; i.e., it wouldn't trigger on a css change. It's possible to make it so that the motationObservers would listen to attribute changes, but coupling attribute observers with the fact that we use css transforms would make the entire thing run very slow. listenToContentChanges now uses a timeout system that will resize the accordion content when necessary without causing too much damage to the browser.

@M-Porter 