### PR TITLE
1.3.5 Updates

### DIFF
--- a/files/js/editor_element.js
+++ b/files/js/editor_element.js
@@ -10,34 +10,9 @@
             // if we have any iframes, we get an overlay
             this.$el.children('.platform-element-overlay').hide();
 
-            this.fixStyles();
+            this.fixBoxStyleBorders();
             this.setupAccordion();
             this.setOpen();
-        },
-
-        /**
-         * Styles are applied by default to editable areas of
-         * the editor. To make the element looks how you want, some styles
-         * need to be overwritten.
-         *
-         * Classes that are used are:
-         *      - .editable-text
-         *      - .paragraph
-         *      - .ui-wrapper
-         *      - .wsite-image
-         *      - .wsite-*
-         *      - (etc...)
-         */
-        fixStyles: function() {
-            this.$el.find('.editable-text').each(function(index) {
-                $(this).attr('style', '');
-            });
-
-            this.$el.find('.element').each(function(index) {
-                $(this).attr('style', '');
-            });
-
-            this.fixBoxStyleBorders();
         },
 
         /**

--- a/files/js/element.js
+++ b/files/js/element.js
@@ -10,33 +10,8 @@
             // if we have any iframes, we get an overlay
             this.$el.children('.platform-element-overlay').hide();
 
-            this.fixStyles();
-            this.setupAccordion();
-        },
-
-        /**
-         * Styles are applied by default to editable areas of
-         * the editor. To make the element looks how you want, some styles
-         * need to be overwritten.
-         *
-         * Classes that are used are:
-         *      - .editable-text
-         *      - .paragraph
-         *      - .ui-wrapper
-         *      - .wsite-image
-         *      - .wsite-*
-         *      - (etc...)
-         */
-        fixStyles: function() {
-            this.$el.find('.editable-text').each(function(index) {
-                $(this).attr('style', '');
-            });
-
-            this.$el.find('.element').each(function(index) {
-                $(this).attr('style', '');
-            });
-
             this.fixBoxStyleBorders();
+            this.setupAccordion();
         },
 
          /**

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest": "1",
-  "version": "1.3.3",
+  "version": "1.3.5",
   "locale": {
     "default": "en-us",
     "supported": [
@@ -11,7 +11,7 @@
     {
       "path": "files",
       "name": "Accordion",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "settings": {
         "config": {},
         "properties": [


### PR DESCRIPTION
remove unnecessary fixStyles for the accordion. All the stuff should start out as left-aligned anyway, so there's no real reason to run these style fixes.

@rchen1992 @M-Porter 