### PR TITLE
Prevent multiple click events from being bound

### DIFF
--- a/files/js/editor_element.js
+++ b/files/js/editor_element.js
@@ -54,7 +54,15 @@
         setupAccordion: function() {
             var view = this;
 
-            this.getTitles().on('touchstart click', function(e) {
+            $titles = this.getTitles();
+            $events = $._data($titles[0], "events");
+
+            // if we already have set up click events, don't set more up
+            if ($events && $events.click && $events.click[0]) {
+                return;
+            }
+
+            $titles.on('touchstart click', function(e) {
                 clearInterval(view.contentInterval);
                 
                 // remove "hover" state on touch events

--- a/files/js/element.js
+++ b/files/js/element.js
@@ -38,7 +38,15 @@
         setupAccordion: function() {
             var view = this;
 
-            this.getTitles().on('touchstart click', function(e) {
+            $titles = this.getTitles();
+            $events = $._data($titles[0], "events");
+
+            // if we already have set up click events, don't set more up
+            if ($events && $events.click && $events.click[0]) {
+                return;
+            }
+
+            $titles.on('touchstart click', function(e) {
                 clearInterval(view.contentInterval);
 
                 // remove "hover" state on touch events

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest": "1",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "locale": {
     "default": "en-us",
     "supported": [
@@ -11,7 +11,7 @@
     {
       "path": "files",
       "name": "Accordion",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "settings": {
         "config": {},
         "properties": [


### PR DESCRIPTION
Checks to see if we've already bound click events once before, before trying to bind new ones.

@rchen1992 @szainmehdi 